### PR TITLE
Update upload-artifact action to v4 to fix deprecated error

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           cd android && ./gradlew assembleRelease
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: app-release.apk
           path: android/app/build/outputs/apk/release/

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=ita-social-projects-10-nr
 
 sonar.projectName=SpaceToStudy-ClientMobile
 
-# Path is relative to the sonar-project.properties file.
+# Path is relative to the sonar-project.properties  file.
 sonar.sources=.
 sonar.exclusions=**/src/tests/**/*, **/jest.config.js
 sonar.coverage.exclusions=**/src/tests/**/*, **/src/constants/**/*, **/*.styles.jsx, **/*.styles.js, **/styles/**/*


### PR DESCRIPTION
Error in a GitHub Actions workflow occurs because an outdated, deprecated version of the actions/upload-artifact action is being used. Update the upload-artifact action to v4 to resolve the deprecated error and ensure the workflow functions correctly with a supported version.